### PR TITLE
merged from Javier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ faster_rcnn_models
 /data/VOCdevkit2007
 data/cache/
 data/pretrain_model/
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.so
 *.o
 faster_rcnn_models
+/data/VOCdevkit2007
+data/cache/
+data/pretrain_model/

--- a/experiments/scripts/faster_rcnn_end2end.sh
+++ b/experiments/scripts/faster_rcnn_end2end.sh
@@ -49,7 +49,7 @@ exec &> >(tee -a "$LOG")
 echo Logging output to "$LOG"
 
 time python ./tools/train_net.py --device ${DEV} --device_id ${DEV_ID} \
-  --weights data/pretrain_model/VGG_imagenet.npy \
+  --weights ${NET} \
   --imdb ${TRAIN_IMDB} \
   --iters ${ITERS} \
   --cfg experiments/cfgs/faster_rcnn_end2end.yml \

--- a/lib/fast_rcnn/train.py
+++ b/lib/fast_rcnn/train.py
@@ -21,7 +21,7 @@ import time
 
 class SolverWrapper(object):
     """A simple wrapper around Caffe's solver.
-    This wrapper gives us control over he snapshotting process, which we
+    This wrapper gives us control over the snapshotting process, which we
     use to unnormalize the learned bounding-box regression weights.
     """
 

--- a/lib/make.sh
+++ b/lib/make.sh
@@ -16,10 +16,10 @@ if [ -d "$CUDA_PATH" ]; then
 
 	g++ -std=c++11 -shared -o roi_pooling.so roi_pooling_op.cc \
 		roi_pooling_op.cu.o -I $TF_INC  -D GOOGLE_CUDA=1 -fPIC $CXXFLAGS \
-		-lcudart -L $CUDA_PATH/lib64
+		-lcudart -L $CUDA_PATH/lib64 -D_GLIBCXX_USE_CXX11_ABI=0 
 else
 	g++ -std=c++11 -shared -o roi_pooling.so roi_pooling_op.cc \
-		-I $TF_INC -fPIC $CXXFLAGS
+		-I $TF_INC -fPIC $CXXFLAGS -D_GLIBCXX_USE_CXX11_ABI=0
 fi
 
 cd ..

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -67,14 +67,21 @@ if __name__ == '__main__':
     print('Using config:')
     pprint.pprint(cfg)
 
-    while not os.path.exists(args.model) and args.wait:
-        print('Waiting for {} to exist...'.format(args.model))
-        time.sleep(10)
-
     weights_filename = os.path.splitext(os.path.basename(args.model))[0]
 
     imdb = get_imdb(args.imdb_name)
     imdb.competition_mode(args.comp_mode)
+
+    # Find the checkpoint directory, or wait until it exists.
+    checkpoint_dir = os.path.dirname(args.model)
+    while True:
+        ckpt = tf.train.get_checkpoint_state(checkpoint_dir)
+        if ckpt and ckpt.model_checkpoint_path:
+            break
+        else:
+            print('Waiting for checkpoint in directory {} to exist...'.format(checkpoint_dir))
+            time.sleep(10)
+
 
     device_name = '/{}:{:d}'.format(args.device,args.device_id)
     print device_name

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     # start a session
     saver = tf.train.Saver()
     sess = tf.Session(config=tf.ConfigProto(allow_soft_placement=True))
-    saver.restore(sess, args.model)
-    print ('Loading model weights from {:s}').format(args.model)
+    saver.restore(sess, ckpt.model_checkpoint_path)
+    print ('Loading model weights from {:s}').format(ckpt.model_checkpoint_path)
 
     test_net(sess, network, imdb, weights_filename)


### PR DESCRIPTION
JavierMares	Make g++ compiled op library compatible with older abi.

Ignore output directory.

	saver.restore loads ckpt.model_checkpoint_path instead of args.model

Train with user specified weights.